### PR TITLE
Added option for image resizing during evaluation

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ model = model.eval().to(args.device)
 
 test_ds = TestDataset(args.database_folder, args.queries_folder,
                       positive_dist_threshold=args.positive_dist_threshold,
-                      resize=args.image_resolution)
+                      image_size=args.image_size)
 logging.info(f"Testing on {test_ds}")
 
 with torch.inference_mode():

--- a/main.py
+++ b/main.py
@@ -28,7 +28,8 @@ model = vpr_models.get_model(args.method, args.backbone, args.descriptors_dimens
 model = model.eval().to(args.device)
 
 test_ds = TestDataset(args.database_folder, args.queries_folder,
-                      positive_dist_threshold=args.positive_dist_threshold)
+                      positive_dist_threshold=args.positive_dist_threshold,
+                      resize = args.image_resolution)
 logging.info(f"Testing on {test_ds}")
 
 with torch.inference_mode():

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ model = model.eval().to(args.device)
 
 test_ds = TestDataset(args.database_folder, args.queries_folder,
                       positive_dist_threshold=args.positive_dist_threshold,
-                      resize = args.image_resolution)
+                      resize=args.image_resolution)
 logging.info(f"Testing on {test_ds}")
 
 with torch.inference_mode():

--- a/parser.py
+++ b/parser.py
@@ -35,8 +35,9 @@ def parse_arguments():
     parser.add_argument("--save_only_wrong_preds", action="store_true",
                         help="set to true if you want to save predictions only for "
                         "wrongly predicted queries")
-    parser.add_argument("--image_size", type=int, default=-1,
-                        help="set the smallest edge of all images to this value, while keeping aspect ratio")
+    parser.add_argument("--image_size", type=int, default=None, nargs="+",
+                        help="Resizing shape for images (HxW). If a single int is passed, set the"
+                        "smallest edge of all images to this value, while keeping aspect ratio")
     args = parser.parse_args()
     
     if args.method == "netvlad":
@@ -110,6 +111,9 @@ def parse_arguments():
     elif args.method == "salad":
         args.backbone = "DINOv2"
         args.descriptors_dimension = 8448
+    
+    if args.image_size and len(args.image_size) > 2:
+        raise ValueError(f"The --image_size parameter can only take up to 2 values, but has received {len(args.image_size)}.")
     
     return args
 

--- a/parser.py
+++ b/parser.py
@@ -35,7 +35,8 @@ def parse_arguments():
     parser.add_argument("--save_only_wrong_preds", action="store_true",
                         help="set to true if you want to save predictions only for "
                         "wrongly predicted queries")
-    
+    parser.add_argument("--image_resolution", type=int, default=-1,
+                        help="set the smallest dimension of all images to this value")
     args = parser.parse_args()
     
     if args.method == "netvlad":

--- a/parser.py
+++ b/parser.py
@@ -35,8 +35,8 @@ def parse_arguments():
     parser.add_argument("--save_only_wrong_preds", action="store_true",
                         help="set to true if you want to save predictions only for "
                         "wrongly predicted queries")
-    parser.add_argument("--image_resolution", type=int, default=-1,
-                        help="set the smallest dimension of all images to this value")
+    parser.add_argument("--image_size", type=int, default=-1,
+                        help="set the smallest edge of all images to this value, while keeping aspect ratio")
     args = parser.parse_args()
     
     if args.method == "netvlad":

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -46,7 +46,7 @@ def read_images_paths(dataset_folder):
 
 
 class TestDataset(data.Dataset):
-    def __init__(self, database_folder, queries_folder, positive_dist_threshold=25):
+    def __init__(self, database_folder, queries_folder, positive_dist_threshold=25, resize=-1):
         """Dataset with images from database and queries, used for validation and test.
         Parameters
         ----------
@@ -88,11 +88,13 @@ class TestDataset(data.Dataset):
         
         self.database_num = len(self.database_paths)
         self.queries_num = len(self.queries_paths)
-        
-        self.base_transform = transforms.Compose([
+        transformations = [
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-        ])
+        ]
+        if resize!=-1:
+            transformations.append(transforms.Resize(size = resize))
+        self.base_transform = transforms.Compose(transformations)
     
     def __getitem__(self, index):
         image_path = self.images_paths[index]

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -92,8 +92,8 @@ class TestDataset(data.Dataset):
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
-        if resize!=-1:
-            transformations.append(transforms.Resize(size = resize))
+        if resize != -1:
+            transformations.append(transforms.Resize(size=resize))
         self.base_transform = transforms.Compose(transformations)
     
     def __getitem__(self, index):

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -46,7 +46,7 @@ def read_images_paths(dataset_folder):
 
 
 class TestDataset(data.Dataset):
-    def __init__(self, database_folder, queries_folder, positive_dist_threshold=25, image_size=-1):
+    def __init__(self, database_folder, queries_folder, positive_dist_threshold=25, image_size=None):
         """Dataset with images from database and queries, used for validation and test.
         Parameters
         ----------
@@ -92,7 +92,7 @@ class TestDataset(data.Dataset):
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
-        if image_size != -1:
+        if image_size:
             transformations.append(transforms.Resize(size=image_size))
         self.base_transform = transforms.Compose(transformations)
     

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -46,7 +46,7 @@ def read_images_paths(dataset_folder):
 
 
 class TestDataset(data.Dataset):
-    def __init__(self, database_folder, queries_folder, positive_dist_threshold=25, resize=-1):
+    def __init__(self, database_folder, queries_folder, positive_dist_threshold=25, image_size=-1):
         """Dataset with images from database and queries, used for validation and test.
         Parameters
         ----------
@@ -92,8 +92,8 @@ class TestDataset(data.Dataset):
             transforms.ToTensor(),
             transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
         ]
-        if resize != -1:
-            transformations.append(transforms.Resize(size=resize))
+        if image_size != -1:
+            transformations.append(transforms.Resize(size=image_size))
         self.base_transform = transforms.Compose(transformations)
     
     def __getitem__(self, index):


### PR DESCRIPTION
To run some heavier models, such as AnyLoc and Salad, it may be useful to reduce the size of the test images. I added an argument to the parser that, when used, change the smaller dimension of all images to the desired value while keeping the same aspect ratio.