### PR TITLE
Add fine-tuned model for indoor environments

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -8,8 +8,8 @@ def parse_arguments():
     parser.add_argument("--positive_dist_threshold", type=int, default=25,
                         help="distance (in meters) for a prediction to be considered a positive")
     parser.add_argument("--method", type=str, default="cosplace",
-                        choices=["netvlad", "apgem", "sfrs", "cosplace", "convap", "mixvpr", "eigenplaces",
-                                 "anyloc", "salad"],
+                        choices=["netvlad", "apgem", "sfrs", "cosplace", "convap", "mixvpr", "eigenplaces", 
+                                 "eigenplaces-indoor", "anyloc", "salad", "salad-indoor"],
                         help="_")
     parser.add_argument("--backbone", type=str, default=None,
                         choices=[None, "VGG16", "ResNet18", "ResNet50", "ResNet101", "ResNet152"],
@@ -104,6 +104,10 @@ def parse_arguments():
             raise ValueError("When using EigenPlaces with ResNet18 the descriptors_dimension must be in [256, 512]")
         if args.backbone in ["ResNet50", "ResNet101", "ResNet152"] and args.descriptors_dimension not in [128, 256, 512, 2048]:
             raise ValueError(f"When using EigenPlaces with {args.backbone} the descriptors_dimension must be in [128, 256, 512, 2048]")
+            
+    elif args.method == "eigenplaces-indoor":
+        args.backbone = "Resnet50"
+        args.descriptors_dimension = 2048
     
     elif args.method == "apgem":
         args.backbone = "Resnet101"
@@ -114,6 +118,10 @@ def parse_arguments():
         args.descriptors_dimension = 49152
     
     elif args.method == "salad":
+        args.backbone = "DINOv2"
+        args.descriptors_dimension = 8448
+        
+    elif args.method == "salad-indoor":
         args.backbone = "DINOv2"
         args.descriptors_dimension = 8448
     

--- a/parser.py
+++ b/parser.py
@@ -106,7 +106,7 @@ def parse_arguments():
             raise ValueError(f"When using EigenPlaces with {args.backbone} the descriptors_dimension must be in [128, 256, 512, 2048]")
             
     elif args.method == "eigenplaces-indoor":
-        args.backbone = "Resnet50"
+        args.backbone = "ResNet50"
         args.descriptors_dimension = 2048
     
     elif args.method == "apgem":
@@ -122,7 +122,7 @@ def parse_arguments():
         args.descriptors_dimension = 8448
         
     elif args.method == "salad-indoor":
-        args.backbone = "DINOv2"
+        args.backbone = "Dinov2"
         args.descriptors_dimension = 8448
     
     if args.image_size and len(args.image_size) > 2:

--- a/vpr_models/__init__.py
+++ b/vpr_models/__init__.py
@@ -28,7 +28,7 @@ def get_model(method, backbone=None, descriptors_dimension=None):
         model = anyloc.AnyLocWrapper()
     elif method == "salad":
         model = salad.SaladWrapper()
-    elif method == "salad_indoor":
+    elif method == "salad-indoor":
         model = salad.SaladIndoorWrapper()
     
     return model

--- a/vpr_models/__init__.py
+++ b/vpr_models/__init__.py
@@ -20,11 +20,16 @@ def get_model(method, backbone=None, descriptors_dimension=None):
         model = convap.get_convap(descriptors_dimension=descriptors_dimension)
     elif method == "eigenplaces":
         model = torch.hub.load("gmberton/eigenplaces", "get_trained_model",
-                               backbone=backbone, fc_output_dim=descriptors_dimension)
+                                backbone=backbone, fc_output_dim=descriptors_dimension)
+    elif method == "eigenplaces-indoor":
+        model = torch.hub.load("Enrico-Chiavassa/Indoor-VPR", "get_trained_model",
+                                backbone=backbone, fc_output_dim=descriptors_dimension)
     elif method == "anyloc":
         model = anyloc.AnyLocWrapper()
     elif method == "salad":
         model = salad.SaladWrapper()
+    elif method == "salad_indoor":
+        model = salad.SaladIndoorWrapper()
     
     return model
 

--- a/vpr_models/salad.py
+++ b/vpr_models/salad.py
@@ -17,3 +17,16 @@ class SaladWrapper(torch.nn.Module):
         images = transforms.functional.resize(images, [h, w], antialias=True)
         return self.model(images)
 
+class SaladIndoorWrapper(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.model = torch.hub.load("Enrico-Chiavassa/Indoor-VPR", "get_trained_model",
+                                    backbone="Dinov2", fc_output_dim=8448)
+    def forward(self, images):
+        b, c, h, w = images.shape
+        # DINO wants height and width as multiple of 14, therefore resize them
+        # to the nearest multiple of 14
+        h = round(h / 14) * 14
+        w = round(w / 14) * 14
+        images = transforms.functional.resize(images, [h, w], antialias=True)
+        return self.model(images)

--- a/vpr_models/salad.py
+++ b/vpr_models/salad.py
@@ -21,7 +21,7 @@ class SaladIndoorWrapper(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self.model = torch.hub.load("Enrico-Chiavassa/Indoor-VPR", "get_trained_model",
-                                    backbone="Dinov2", fc_output_dim=8448)
+                                    method="salad", backbone="Dinov2", fc_output_dim=8448)
     def forward(self, images):
         b, c, h, w = images.shape
         # DINO wants height and width as multiple of 14, therefore resize them


### PR DESCRIPTION
Add fine-tuned model for indoor environments. Users can now select methods "eigenplaces-indoor" and "salad-indoor" in "method" argument. The former is loaded similarly to the normal eigenplaces model. The latter is loaded using a class similar to SaladWrapper. At the moment the choices of backbone and descriptors dimension are very limited, but may be expanded in the future.