### PR TITLE
Added way to save descriptors and pairsfile

### DIFF
--- a/extract_descriptors.py
+++ b/extract_descriptors.py
@@ -1,0 +1,57 @@
+
+import argparse
+import faiss
+import logging
+import numpy as np
+import sys
+import torch
+
+from datetime import datetime
+from pathlib import Path
+from torch.utils.data import DataLoader
+from torch.utils.data.dataset import Subset
+from tqdm import tqdm
+
+import commons
+import parser
+import save
+from test_dataset import ExtractDescriptorsDataset
+import vpr_models
+
+
+args = parser.parse_arguments("extract")
+if args.remove_timestamp:
+    log_dir = Path("logs") / args.log_dir
+else:
+    start_time = datetime.now()
+    log_dir = Path("logs") / args.log_dir / start_time.strftime('%Y-%m-%d_%H-%M-%S')
+commons.setup_logging(log_dir, stdout="info")
+logging.info(" ".join(sys.argv))
+logging.info(f"Arguments: {args}")
+logging.info(f"Testing with {args.method} with a {args.backbone} backbone and descriptors dimension {args.descriptors_dimension}")
+logging.info(f"The logs are being saved in {log_dir}")
+
+model = vpr_models.get_model(args.method, args.backbone, args.descriptors_dimension)
+model = model.eval().to(args.device)
+
+test_ds = ExtractDescriptorsDataset(args.database_folder, image_size=args.image_size)
+
+logging.info(f"Extracting the descriptors of {test_ds}")
+
+with torch.inference_mode():
+    database_dataloader = DataLoader(dataset=test_ds, num_workers=args.num_workers,
+                                    batch_size=args.batch_size)
+    all_descriptors = np.empty((len(test_ds), args.descriptors_dimension), dtype="float32")
+    for images, indices in tqdm(database_dataloader):
+        descriptors = model(images.to(args.device))
+        descriptors = descriptors.cpu().numpy()
+        all_descriptors[indices.numpy(), :] = descriptors
+
+if not args.output_dir:
+    args.output_dir = log_dir
+else:
+    args.output_dir = Path(args.output_dir)
+
+logging.info(f"Saving the descriptors of {test_ds} in {args.output_dir}")
+save.save_descriptors(args, test_ds=test_ds, descriptors=all_descriptors)
+    

--- a/save.py
+++ b/save.py
@@ -1,0 +1,43 @@
+
+import numpy
+import pickle
+
+from pathlib import Path
+
+def save_descriptors(args, test_ds, descriptors):
+    if args.save_descriptors == "kapture":
+        images_rel_paths = test_ds.get_images_rel_paths()
+        with open(args.output_dir / "global_features.txt", "w") as file:
+            file.write("# kapture format: 1.1\n")
+            file.write("# Salad - See: https://github.com/serizba/salad\n") # Should point the the github of the used method
+            file.write("# name, dtype, dsize, metric_type\n")
+            file.write(f"{args.method}, {str(descriptors.dtype)}, {descriptors[0].shape[0]}, L2")
+        
+        for image_rel_path, image_descriptor in zip(images_rel_paths, descriptors):
+            dir_name = args.output_dir / image_rel_path
+            dir_name.parent.mkdir(parents=True, exist_ok=True)
+            dir_name = dir_name.with_suffix(".jpg.gfeat")
+            with open(dir_name, "wb") as file:
+                image_descriptor.squeeze().tofile(file, sep="")
+    else:
+        with open(args.output_dir / "global_features.pickle", "wb") as file:
+            pickle.dump(descriptors, file)
+
+def save_pairsfile(args, test_ds, predictions, distances):
+    pred_paths_dir = args.output_dir / "predictions_paths.txt"
+    if args.rel_paths_in_pairsfile:
+        rel_paths = test_ds.get_images_rel_paths()
+        db_paths = rel_paths[:test_ds.num_database]
+        q_paths = rel_paths[test_ds.num_database:]
+    else:
+        db_paths = test_ds.database_paths
+        q_paths = test_ds.queries_paths
+    rows = []
+    for query_index, preds in enumerate(predictions):
+        for pred_index, pred in enumerate(preds[:args.num_candidates_in_pairsfile]):
+            row = [q_paths[query_index]]
+            row.append(db_paths[pred])
+            row.append(f"{distances[query_index, pred_index]:.4f}")
+            rows.append(" ".join(row)+"\n")
+    with open(pred_paths_dir, "w") as file:
+        file.writelines(rows)

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -136,7 +136,7 @@ class ExtractDescriptorsDataset(data.Dataset):
 
         self.data_folder = data_folder.rstrip("/")
 
-        self.data_paths = read_images_paths(data_folder)[:50]
+        self.data_paths = read_images_paths(data_folder)
 
         self.images_paths = list(self.data_paths)
         self.rel_images_paths = None


### PR DESCRIPTION
I found this repo to be extremely useful in VPR tasks as it grants quick access to a large variety of methods. I added a simple way to get the main.py script to save the descriptors that the model extracted and/or the pairsfile containing the candidates for each query. I also added a different script to simply extract and save descriptors from images in single folder (thus not requiring a db/query split)
For now the descriptors can be saved in a single file using pickle or in the kapture format (see https://github.com/naver/kapture), which I found useful in 3D reconstruction pipelines.

The purpose of these changes is to make this repo work within a larger pipeline, which requires more than evaluation.
