### PR TITLE
Fix MixVPR error messages in parser

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -159,7 +159,7 @@ def parse_arguments():
         if args.backbone not in [None, "ResNet50"]:
             raise ValueError("When using MixVPR the backbone must be None or ResNet50")
         if args.descriptors_dimension not in [None, 128, 512, 4096]:
-            raise ValueError( "When using MixVPR the descriptors_dimension must be one of [None, 128, 512, 4096]")
+            raise ValueError("When using MixVPR the descriptors_dimension must be one of [None, 128, 512, 4096]")
 
     elif args.method == "eigenplaces":
         if args.backbone is None:

--- a/parser.py
+++ b/parser.py
@@ -157,9 +157,9 @@ def parse_arguments():
         if args.descriptors_dimension is None:
             args.descriptors_dimension = 4096
         if args.backbone not in [None, "ResNet50"]:
-            raise ValueError("When using Conv-AP the backbone must be None or ResNet50")
+            raise ValueError("When using MixVPR the backbone must be None or ResNet50")
         if args.descriptors_dimension not in [None, 128, 512, 4096]:
-            raise ValueError("When using Conv-AP the descriptors_dimension must be one of [None, 128, 512, 4096]")
+            raise ValueError( "When using MixVPR the descriptors_dimension must be one of [None, 128, 512, 4096]")
 
     elif args.method == "eigenplaces":
         if args.backbone is None:


### PR DESCRIPTION
The validation error messages in the MixVPR section of parser.py
incorrectly refer to Conv-AP.

This updates both messages to refer to MixVPR instead.